### PR TITLE
Fix train_lenet_decolle_fa.py import issue

### DIFF
--- a/scripts/train_lenet_decolle_fa.py
+++ b/scripts/train_lenet_decolle_fa.py
@@ -9,7 +9,7 @@
 # Copyright : (c) UC Regents, Emre Neftci
 # Licence : GPLv2
 #-----------------------------------------------------------------------------
-from decolle.lenet_decolle_model import LenetDECOLLE, DECOLLELoss, LIFLayerVariableTau, LIFLayer
+from decolle.lenet_decolle_model_fa import LenetDECOLLEFA, DECOLLELoss, LIFLayerVariableTau, LIFLayer
 from decolle.utils import parse_args, train, test, accuracy, save_checkpoint, load_model_from_checkpoint, prepare_experiment, write_stats, cross_entropy_one_hot
 import datetime, os, socket, tqdm
 import numpy as np


### PR DESCRIPTION
Was importing standard decolle rather than decolle_fa modules.